### PR TITLE
Fix default value of `$UnifiedContentPath`

### DIFF
--- a/Clean-ExchangeLogs.ps1
+++ b/Clean-ExchangeLogs.ps1
@@ -6,7 +6,7 @@ $IISLogPath = "C:\inetpub\logs\LogFiles\"
 $ExchangeLoggingPath = "C:\Program Files\Microsoft\Exchange Server\V15\Logging\"
 $ETLLoggingPath = "C:\Program Files\Microsoft\Exchange Server\V15\Bin\Search\Ceres\Diagnostics\ETLTraces\"
 $ETLLoggingPath2 = "C:\Program Files\Microsoft\Exchange Server\V15\Bin\Search\Ceres\Diagnostics\Logs\"
-$UnifiedContentPath = "D:\Exchange Server\TransportRoles\data\Temp\UnifiedContent"
+$UnifiedContentPath = "C:\Program Files\Microsoft\Exchange Server\V15\TransportRoles\data\Temp\UnifiedContent"
 
 # Test if evelated Shell
 Function Confirm-Administrator {


### PR DESCRIPTION
Hello,

I've noticed that the scripts value for the `$UnifiedContentPath` variables does not uses the default path of an exchange server installation. Therefore the script is not able to calculate the correct sum for the files to be deleted and breaks during execution.

This pull requests sets the value for the above metioned variable to the default installation path.

Thank you for the helpful script!